### PR TITLE
MySQL is started too late

### DIFF
--- a/config/salt/vagrant.sls
+++ b/config/salt/vagrant.sls
@@ -18,6 +18,7 @@ wordpress-trunk:
     - unless: cd /srv/www/wordpress-trunk.dev; wp core is-installed
     - require:
       - cmd: wp_cli
+      - service: mysql
 
 
 wp-cli-tests-mysql:


### PR DESCRIPTION
You end up with errors like this:

```
----------
    State: - mysql_database
    Name:      wordpress_trunk
    Function:  present
        Result:    False
        Comment:   MySQL Error 2002: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
        Changes:   
----------
    State: - mysql_database
    Name:      wp_cli_test
    Function:  present
        Result:    False
        Comment:   MySQL Error 2002: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
        Changes:   
----------
    State: - mysql_grants
    Name:      wp-cli-tests-mysql
    Function:  present
        Result:    False
        Comment:   MySQL Error 2002: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
        Changes:   
----------
    State: - mysql_user
    Name:      wp_cli_test
    Function:  present
        Result:    False
        Comment:   MySQL Error 2002: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
        Changes:   
```
