### PR TITLE
Hub is broken

### DIFF
--- a/config/salt/tools/ruby.sls
+++ b/config/salt/tools/ruby.sls
@@ -5,7 +5,7 @@ ruby:
 
 ruby-hub:
   cmd.run:
-    - name: curl http://defunkt.io/hub/standalone -sLo /usr/bin/hub && chmod +x /usr/bin/hub
+    - name: curl http://hub.github.com/standalone -sLo /usr/bin/hub && chmod +x /usr/bin/hub
     - unless: ls /usr/bin/hub
   require:
     - name: ruby


### PR DESCRIPTION
Annoying:

```
salty-wordpress ➜  wp-cli  hub
/usr/lib/ruby/1.9.1/rubygems/dependency.rb:247:in `to_specs': Could not find hub (>= 0) amongst [] (Gem::LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/dependency.rb:256:in `to_spec'
    from /usr/lib/ruby/1.9.1/rubygems.rb:1231:in `gem'
    from /usr/local/bin/hub:22:in `<main>'
```
