### PR TITLE
Automatically handle internal requests to *.dev domains

### DIFF
--- a/config/salt/vagrant.sls
+++ b/config/salt/vagrant.sls
@@ -62,7 +62,8 @@ dnsmasq:
     - installed
   service.running:
     - name: dnsmasq
-
-/etc/dnsmasq.conf:
+    - watch:
+      - file: /etc/dnsmasq.conf
   file.managed:
+    - name: /etc/dnsmasq.conf
     - contents: address=/.dev/192.168.50.10


### PR DESCRIPTION
Requests inside Vagrant to `*.dev` domains should be automatically routed — developers shouldn't have to set up `/etc/hosts` records inside of Vagrant.
