### PR TITLE
Block web requests to Grunt config files

### DIFF
--- a/config/salt/config/nginx/default
+++ b/config/salt/config/nginx/default
@@ -24,7 +24,7 @@ server {
                 rewrite ^(/wp-(admin|includes)/(.*))$ /wordpress$1 last;
                 rewrite ^(/wp-[^/]*\.php)$ /wordpress$1 last;
         }
-        
+
         # rewrite for multisite in subdirs, e.g. example.com/subsite1/
         # if the file doest exist for wp-admin/* or wp-*.php, try looking in the parent dir
         if ( !-e $request_filename ) {
@@ -32,8 +32,8 @@ server {
                 rewrite ^(/[^/]+)?(/wp-.*) $2 last;
                 rewrite ^(/[^/]+)?(/.*\.php) $2 last;
         }
-        
-        # wordpress multisite files handler (this is technically legacy but 
+
+        # wordpress multisite files handler (this is technically legacy but
         # still used on a lot of mutlisite installs)
         location ~ ^(/[^/]+/)?files/(.+) {
                 try_files $uri /wp-includes/ms-files.php?file=$2 ;


### PR DESCRIPTION
Now that we support using Grunt to compile LESS, concat JS, etc., we should make sure project-specific configuration files aren't publicly accessible.

This can be done by adding an entry in our Nginx `default` conf.

Related #29 
