### PR TITLE
Config for wordpress-trunk.dev not available after initial `vagrant up`

### DIFF
--- a/config/salt/vagrant.sls
+++ b/config/salt/vagrant.sls
@@ -18,7 +18,11 @@ wordpress-trunk:
     - unless: cd /srv/www/wordpress-trunk.dev; wp core is-installed
     - require:
       - cmd: wp_cli
+      - file: wp_cli
+      - git: git://github.com/WordPress/WordPress.git
+      - mysql_database: wordpress_trunk
       - service: mysql
+      - pkg: php5-mysql
 
 
 wp-cli-tests-mysql:


### PR DESCRIPTION
I did a `vagrant up` from scratch with Salty WordPress tonight and it seems that the [wp-cli commands](https://github.com/humanmade/Salty-WordPress/blob/master/config/salt/vagrant.sls#L17) didn't run properly during provisioning. No `wp-config.php` file was created.

A subsequent `vagrant provision` caused the commands to run fine, `wp-config.php` was created successfully, and `http://wordpress-trunk.dev` worked as expected.
