### PR TITLE
Disable error reporting in production

### DIFF
--- a/config/salt/config/php5-fpm/php.ini
+++ b/config/salt/config/php5-fpm/php.ini
@@ -35,7 +35,7 @@ memory_limit = 128M
 {% if grains['user'] == 'vagrant' %}
 error_reporting = E_ALL | E_STRICT
 {% else %}
-Production Value: E_ALL & ~E_DEPRECATED
+error_reporting = E_ALL & ~E_DEPRECATED
 {% endif %}
 
 ; Should PHP output errors. If so, where?


### PR DESCRIPTION
Our `php.ini` file enables error reporting for all environments. We should disable it for production.
