### PR TITLE
Install Ruby & Compass in system PATH for proper function of grunt tasks

### DIFF
--- a/config/salt/tools/ruby.sls
+++ b/config/salt/tools/ruby.sls
@@ -13,3 +13,7 @@ ruby-hub:
 ruby-rmate:
   gem.installed:
     - name: rmate
+
+ruby-compass:
+  gem.installed:
+    - name: compass


### PR DESCRIPTION
Error message when running grunt watch & trying to compile .scss files with Compass:

Warning: You need to have Ruby and Compass installed and in your system PATH for this task to work. More info: https://github.com/gruntjs/grunt-contrib-compass Use --force to continue.
