### PR TITLE
Reduce the maximum allowed POST

### DIFF
--- a/config/salt/config/nginx/default
+++ b/config/salt/config/nginx/default
@@ -9,7 +9,7 @@ server {
                 set $root $2;
         }
 
-        client_max_body_size 1G;
+        client_max_body_size 50M;
 
         if ( !-d /srv/www/$root ) {
                 set $root 'default';

--- a/config/salt/config/php5-fpm/php.ini
+++ b/config/salt/config/php5-fpm/php.ini
@@ -107,11 +107,11 @@ error_log = /var/log/php.log
 
 ; Maximum size of POST data that PHP will accept.
 ; http://php.net/post-max-size
-post_max_size = 1G
+post_max_size = 50M
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 1G
+upload_max_filesize = 50M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
Our Nginx conf and `php.ini` both permit a maximum POST of 1G because a project requires it.

We should move this to the project grain SLS and reduce the default in Salty WordPress.
