### PR TITLE
Make sure Salt is managing php.ini as a proper template

### DIFF
--- a/config/salt/php_fpm.sls
+++ b/config/salt/php_fpm.sls
@@ -72,6 +72,7 @@ composer:
     - source: salt://config/php5-fpm/php.ini
     - user: root
     - group: root
+    - template: jinja
     - mode: 644
 
 /etc/php5/fpm/pool.d/www.conf:


### PR DESCRIPTION
Otherwise, it dumps our conditional logic into the template.

Previously #2
