### PR TITLE
Avoid annoying ZSH prompt

### DIFF
--- a/config/salt/config/zshrc
+++ b/config/salt/config/zshrc
@@ -22,6 +22,8 @@ ZSH_THEME="joeyhoyle"
 # Example format: plugins=(rails git textmate ruby lighthouse)
 plugins=(autojump)
 
+DISABLE_AUTO_UPDATE="true"
+
 [[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm" 
 
 source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
There's got to be some cache file we can set to avoid this prompt:

```
[Oh My Zsh] Would you like to check for updates?
Type Y to update oh-my-zsh: n
```
