### PR TITLE
Set a sane innodb_buffer_pool_size limit

### DIFF
--- a/config/salt/config/mysql/my.cnf
+++ b/config/salt/config/mysql/my.cnf
@@ -96,7 +96,9 @@ max_binlog_size         = 100M
 # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
 # Read the manual for more InnoDB related options. There are many!
 
+{% if grains['user'] == 'vagrant' %}
 innodb_buffer_pool_size = 40M
+{% else %}
 
 #
 # * Security Features


### PR DESCRIPTION
On my local I often run into the following fatal mysql issue, I'm forced to re-start the service to recover.

The root of the issue is that we aren't setting a `innodb_buffer_pool_size` in `my.cnf` and so it's defaulting to `128MB` which is more memory than mysql has available to it.

Setting my `innodb_buffer_pool_size = 40M` fixed the issue for me.

Here's the complete error:

```
130529 18:41:01 InnoDB: Initializing buffer pool, size = 128.0M 
InnoDB: mmap(137363456 bytes) failed; errno 12 
130529 18:41:01 InnoDB: Completed initialization of buffer pool 
130529 18:41:01 InnoDB: Fatal error: cannot allocate memory for the buffer pool 
130529 18:41:01 [ERROR] Plugin 'InnoDB' init function returned error. 
130529 18:41:01 [ERROR] Plugin 'InnoDB' registration as a STORAGE ENGINE failed. 
130529 18:41:01 [ERROR] Unknown/unsupported storage engine: InnoDB 
130529 18:41:01 [ERROR] Aborting 
```

See here for some background: 
- http://stackoverflow.com/questions/12114746/mysqld-service-stops-once-a-day-on-ec2-server
- http://stackoverflow.com/questions/10284532/amazon-ec2-mysql-aborting-start-because-innodb-mmap-x-bytes-failed-errno-12
