### PR TITLE
NFS mounting issues with VMWare Fusion provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Here's how to get building:
 
 1. Clone the repo: `cd ~/; git clone git@github.com:humanmade/Salty-WordPress.git`.
 1. Install the latest version of [Vagrant](http://downloads.vagrantup.com/) and version 4.2.12 of [Virtual Box](https://www.virtualbox.org/wiki/Download_Old_Builds_4_2).
+1. Salty WordPress can also be used with VMWare 6.x instead of Virtualbox. There is a known issue where you'll need to install `nfs-common` in the VM before your shared directories will work. This will be fixed in Vagrant 1.5.
 1. Change into the Salty WordPress directory and run `vagrant up`. This will take some time. Behind the scenes, Vagrant and Salt are downloading all of the system utilities (e.g. Nginx, PHP5-FPM, Memcached, etc.) to run your virtual machine.
 1. In your `/etc/hosts` file, point any domains you plan to work on to `192.168.50.10`. The virtual machine is configured to handle all requests to `*.dev`. The WordPress trunk install, for instance, should be `wordpress-trunk.dev`.
 1. Access your virtual machine with `vagrant ssh`.


### PR DESCRIPTION
When bringing up the box for the first time with VMWare Fusion, I received an error when attempting to mount the NFS shared folders. The error was similar to [one reported in the Vagrant project](https://github.com/mitchellh/vagrant/issues/129). I solved the issue by running `vagrant up`, waiting for it to fail, ssh'ing into the machine and running `apt-get install nfs-common`. I then ran `vagrant reload`. Ideally, this package would be installed in the base box prior to provisioning. Perhaps this can be explored as the box is updated to 13.10 as suggested in #67.
