### PR TITLE
Set the highstate output to "mixed" on "vagrant provision"

### DIFF
--- a/config/salt/minions/vagrant.conf
+++ b/config/salt/minions/vagrant.conf
@@ -12,3 +12,5 @@ grains:
   user: vagrant
   project: salty-wordpress
   role: salt-minion
+
+state_output: mixed


### PR DESCRIPTION
This gives us a much easier to read output on `vagrant provision`:

```
local:
 Name: git - Function: pkg.installed - Result: True
 Name: git://github.com/WordPress/WordPress.git - Function: git.latest - Result: True
 Name: mysql-server-5.5 - Function: pkg.installed - Result: True
 Name: /etc/mysql/my.cnf - Function: file.managed - Result: True
 Name: mysql - Function: service.running - Result: True
 Name: python-mysqldb - Function: pkg.installed - Result: True
 Name: wordpress_trunk - Function: mysql_database.present - Result: True
 Name: php5-cli - Function: pkg.installed - Result: True
 Name: curl https://raw.github.com/wp-cli/wp-cli.github.com/master/installer.sh | bash - Function: cmd.run - Result: True
 Name: /usr/bin/wp - Function: file.symlink - Result: True
 Name: php5-mysql - Function: pkg.installed - Result: True
 Name: cd /srv/www/wordpress-trunk.dev; wp core config --dbname=wordpress_trunk --dbuser=root; wp core install --title="Salty WordPress" --url=http://wordpress-trunk.dev --admin_name=humanmade --admin_password=humanmade --admin_email=hello@hmn.md - Function: cmd.run - Result: True
 Name: wp_cli_test - Function: mysql_user.present - Result: True
 Name: wp_cli_test - Function: mysql_database.present - Result: True
 Name: wp-cli-tests-mysql - Function: mysql_grants.present - Result: True
 Name: php-pear - Function: pkg.installed - Result: True
 Name: pear channel-discover pear.phpunit.de ; pear config-set auto_discover 1 ; sudo pear install phpunit/PHPUnit - Function: cmd.run - Result: True
 Name: /var/log/php.log - Function: file.symlink - Result: True
 Name: dnsmasq - Function: pkg.installed - Result: True
 Name: /etc/dnsmasq.conf - Function: file.managed - Result: True
 Name: dnsmasq - Function: service.running - Result: True
 Name: ruby - Function: pkg.installed - Result: True
 Name: curl http://hub.github.com/standalone -sLo /usr/bin/hub && chmod +x /usr/bin/hub - Function: cmd.run - Result: True
 Name: rmate - Function: gem.installed - Result: True
 Name: compass - Function: gem.installed - Result: True
 Name: python-dev - Function: pkg.installed - Result: True
 Name: memcached - Function: pkg.installed - Result: True
 Name: memcached - Function: service.running - Result: True
 Name: npm-repo - Function: pkgrepo.managed - Result: True
 Name: nodejs - Function: pkg.installed - Result: True
 Name: npm - Function: pkg.installed - Result: True
 Name: sass - Function: gem.installed - Result: True
 Name: grunt-cli - Function: npm.installed - Result: True
 Name: vim - Function: pkg.installed - Result: True
 Name: nano - Function: pkg.installed - Result: True
 Name: autojump - Function: pkg.installed - Result: True
 Name: ntp - Function: pkg.installed - Result: True
 Name: ntp - Function: service.running - Result: True
 Name: curl - Function: pkg.installed - Result: True
 Name: deb http://ppa.launchpad.net/git-core/ubuntu/ precise main - Function: pkgrepo.managed - Result: True
 Name: subversion - Function: pkg.installed - Result: True
 Name: tig - Function: pkg.installed - Result: True
 Name: zip - Function: pkg.installed - Result: True
 Name: ack-grep - Function: pkg.installed - Result: True
 Name: zsh - Function: pkg.installed - Result: True
 Name: htop - Function: pkg.installed - Result: True
 Name: git://github.com/robbyrussell/oh-my-zsh.git - Function: git.latest - Result: True
 Name: /etc/init/salty-wordpress.conf - Function: file.managed - Result: True
 Name: /home/vagrant/.zshrc - Function: file.managed - Result: True
 Name: /home/vagrant/.oh-my-zsh/themes/joeyhoyle.zsh-theme - Function: file.managed - Result: True
 Name: vagrant - Function: user.present - Result: True
 Name: github.com - Function: ssh_known_hosts.present - Result: True
 Name: nginx - Function: pkg.installed - Result: True
 Name: /etc/nginx/nginx.conf - Function: file.managed - Result: True
 Name: /etc/nginx/sites-enabled/default - Function: file.managed - Result: True
 Name: nginx - Function: service.running - Result: True
 Name: /srv/www - Function: file.directory - Result: True
----------
    State: - file
    Name:      /srv/www/default/index.php
    Function:  managed
        Result:    False

     Comment:   An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1315, in call
    *cdata['args'], **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/states/file.py", line 1157, in managed
    dir_mode)
  File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 2124, in manage_file
Set the highstate output to "mixed" on "vagrant provision"
    if touch(name):
  File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 1255, in touch
    raise CommandExecutionError(exc.strerror)
CommandExecutionError: Permission denied

        Changes:
 Name: php5-fpm - Function: pkg.installed - Result: True
 Name: php5-gd - Function: pkg.installed - Result: True
 Name: php5-json - Function: pkg.installed - Result: True
 Name: php5-memcache - Function: pkg.installed - Result: True
 Name: php5-mcrypt - Function: pkg.installed - Result: True
 Name: php5-curl - Function: pkg.installed - Result: True
 Name: php-apc - Function: pkg.installed - Result: True
 Name: mysql-client - Function: pkg.installed - Result: True
 Name: /etc/php5/fpm/php.ini - Function: file.managed - Result: True
 Name: /etc/php5/fpm/pool.d/www.conf - Function: file.managed - Result: True
 Name: php5-fpm - Function: service.running - Result: True
 Name: php5-imagick - Function: pkg.installed - Result: True
 Name: imagemagick - Function: pkg.installed - Result: True
 Name: libssh2-1-dev - Function: pkg.installed - Result: True
 Name: libssh2-php - Function: pkg.installed - Result: True
 Name: curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer - Function: cmd.run - Result: True
 Name: postfix - Function: pkg.installed - Result: True
 Name: /etc/postfix/main.cf - Function: file.managed - Result: True
 Name: postfix - Function: service.running - Result: True

Summary
-------------
Succeeded: 76
Failed:     1
-------------
Total:     77
```
