### PR TITLE
Allows WP-Cli to run as root

### DIFF
--- a/config/salt/vagrant.sls
+++ b/config/salt/vagrant.sls
@@ -14,7 +14,7 @@ wordpress-trunk:
       - service: mysql
       - pkg: python-mysqldb
   cmd.run:
-    - name: cd /srv/www/wordpress-trunk.dev; wp core config --dbname=wordpress_trunk --dbuser=root; wp core install --title="Salty WordPress" --url=http://wordpress-trunk.dev --admin_name=humanmade --admin_password=humanmade --admin_email=hello@hmn.md
+    - name: cd /srv/www/wordpress-trunk.dev; wp core config --allow-root --dbname=wordpress_trunk --dbuser=root; wp core install --title="Salty WordPress" --url=http://wordpress-trunk.dev --admin_name=humanmade --admin_password=humanmade --admin_email=hello@hmn.md --allow-root
     - unless: cd /srv/www/wordpress-trunk.dev; wp core is-installed
     - require:
       - cmd: wp_cli


### PR DESCRIPTION
Closes #82
- Added the `--allow-root` flag to both places
