### PR TITLE
WP-Cli fails to install WordPress as root user

### DIFF
--- a/config/salt/vagrant.sls
+++ b/config/salt/vagrant.sls
@@ -16,6 +16,7 @@ wordpress-trunk:
   cmd.run:
     - name: cd /srv/www/wordpress-trunk.dev; wp core config --dbname=wordpress_trunk --dbuser=root; wp core install --title="Salty WordPress" --url=http://wordpress-trunk.dev --admin_name=humanmade --admin_password=humanmade --admin_email=hello@hmn.md
     - unless: cd /srv/www/wordpress-trunk.dev; wp core is-installed
+    - user: {{ grains['user'] }}
     - require:
       - cmd: wp_cli
       - file: wp_cli


### PR DESCRIPTION
While running `vagrant up` on a freshly cloned repository, one of the installations out of 74 fails. Details below:

```
----------
    State: - cmd
    Name:      cd /srv/www/wordpress-trunk.dev; wp core config --dbname=wordpress_trunk --dbuser=root; wp core install --title="Salty WordPress" --url=http://wordpress-trunk.dev --admin_name=humanmade --admin_password=humanmade --admin_email=hello@hmn.md
    Function:  run
        Result:    False
        Comment:   Command "cd /srv/www/wordpress-trunk.dev; wp core config --dbname=wordpress_trunk --dbuser=root; wp core install --title="Salty WordPress" --url=http://wordpress-trunk.dev --admin_name=humanmade --admin_password=humanmade --admin_email=hello@hmn.md" run
        Changes:   pid: 11093
                   retcode: 1
                   stderr: Error: YIKES! It looks like you're running this as root. You probably meant to run this as the user that your WordPress install exists under.

If you REALLY mean to run this as root, we won't stop you, but just bear in mind that any code on this site will then have full control of your server, making it quite DANGEROUS.

If you'd like to continue as root, please run this again, adding this flag:  --allow-root

If you'd like to run it as the user that this site is under, you can run the following to become the respective user:

    sudo -u USER -i -- wp ...


Error: YIKES! It looks like you're running this as root. You probably meant to run this as the user that your WordPress install exists under.

If you REALLY mean to run this as root, we won't stop you, but just bear in mind that any code on this site will then have full control of your server, making it quite DANGEROUS.

If you'd like to continue as root, please run this again, adding this flag:  --allow-root

If you'd like to run it as the user that this site is under, you can run the following to become the respective user:

    sudo -u USER -i -- wp ...
                   stdout:
```

Logging in to the box and running the same command as-is succeeds though.
