### PR TITLE
Force host dns resolution for guest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure("2") do |config|
 
 	config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", 512]
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
   config.vm.box = "saucy-1310-64bit-virtualbox"


### PR DESCRIPTION
Issue on osx 10.9.2 with virtualbox 4.3.8 where dns queries through certain
programs like curl were timing out. Adding in config line from
:https://leap.se/code/issues/1089 resolved the issue.

Fixes #93
