### PR TITLE
WP-CLI 404s when attempting to install

### DIFF
--- a/config/salt/tools.sls
+++ b/config/salt/tools.sls
@@ -64,16 +64,13 @@ htop:
 
 wp_cli:
   cmd.run:
-    - name: curl https://raw.githubusercontent.com/wp-cli/wp-cli.github.com/master/installer.sh | bash
+    - name: curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar; chmod +x wp-cli.phar; sudo mv wp-cli.phar /usr/bin/wp
     - unless: which wp
     - user: {{ grains['user'] }}
     - require:
       - pkg: php5-cli
       - pkg: php5-json
       - pkg: git
-  file.symlink:
-    - name: /usr/bin/wp
-    - target: /home/{{ grains['user'] }}/.wp-cli/bin/wp
 
 wp_cli_bash:
   file.managed:

--- a/config/salt/vagrant.sls
+++ b/config/salt/vagrant.sls
@@ -19,7 +19,6 @@ wordpress-trunk:
     - user: {{ grains['user'] }}
     - require:
       - cmd: wp_cli
-      - file: wp_cli
       - git: git://github.com/WordPress/WordPress.git
       - mysql_database: wordpress_trunk
       - service: mysql


### PR DESCRIPTION
Looks like installer.sh got killed, https://raw.githubusercontent.com/wp-cli/wp-cli.github.com/master/installer.sh is now returning a 404.
