### PR TITLE
Set `default_server` attribute for default Nginx config

### DIFF
--- a/config/salt/config/nginx/default
+++ b/config/salt/config/nginx/default
@@ -1,5 +1,5 @@
 server {
-        listen   80;
+        listen 80 default_server;
 
         set $root $host;
 


### PR DESCRIPTION
If other server configs are included in `sites-enabled`, this ensures the
default config is still used
