### PR TITLE
Run Nginx as `vagrant` locally

### DIFF
--- a/config/salt/config/nginx/nginx.conf
+++ b/config/salt/config/nginx/nginx.conf
@@ -1,4 +1,8 @@
+{% if grains['user'] == 'vagrant' %}
+user vagrant;
+{% else %}
 user www-data;
+{% endif %}
 worker_processes 4;
 pid /run/nginx.pid;
 


### PR DESCRIPTION
This ensures Nginx has approporiate permissions to run utilities like `stat()`
when the files are owned by `vagrant`
