### PR TITLE
add /src support to nginx config

### DIFF
--- a/config/salt/config/nginx/default
+++ b/config/salt/config/nginx/default
@@ -16,7 +16,7 @@ server {
         }
 
         # For WordPress develop.
-        if ( -d /srv/www/$root/src ) {
+        if ( -d /srv/www/wordpress-develop.dev/src ) {
                 set $root $root/src;
         }
 


### PR DESCRIPTION
Now that Wordpress develop has been added - we should handle the fact that it is in the /src directory.

It might be nice if this could intelligently check for the presence of the `/build` directory too and use that when available - in case you want to test the complied version.... although maybe nobody would want that!

I have a client site that uses a `public` directory in the git repo root - and I have just added a similar line to the nginx config to support this
