### PR TITLE
Add php5-intl package

### DIFF
--- a/config/salt/php_fpm.sls
+++ b/config/salt/php_fpm.sls
@@ -47,6 +47,10 @@ php_imagick:
   pkg.installed:
     - name: php5-imagick
 
+php_intl:
+  pkg.installed:
+    - name: php5-intl
+
 # php5-imagick also requires imagemagick
 imagemagick:
   pkg.installed


### PR DESCRIPTION
Was trying to get http://php.net/manual/en/class.numberformatter.php working. @sanchothefat mentioned we need this package for it for work :)