### PR TITLE
Use phpunit 4.8

### DIFF
--- a/config/salt/vagrant.sls
+++ b/config/salt/vagrant.sls
@@ -48,7 +48,7 @@ wp-cli-tests-mysql:
 
 php_phpunit:
   cmd.run:
-    - name: wget https://phar.phpunit.de/phpunit.phar && chmod +x phpunit.phar && sudo mv phpunit.phar /usr/local/bin/phpunit
+    - name: wget https://phar.phpunit.de/phpunit-old.phar && chmod +x phpunit-old.phar && sudo mv phpunit-old.phar /usr/local/bin/phpunit
     - unless: which phpunit
 
 


### PR DESCRIPTION
PHPUnit 5.0 requires PHP 5.6. Unfortunately we're stuck on 5.5.9 at the moment. Until such a time that we can switch to 5.6 we'll need to install the previous version of PHPUnit, 4.8.x

If you provision a fresh copy of Salty and try to use the version of PHPUnit it ships with you currently get:

```
This version of PHPUnit requires PHP 5.6; using the latest version of PHP is highly recommended.
```