### PR TITLE
Use the correct filename for the nightly build of wp-cli

### DIFF
--- a/config/salt/tools.sls
+++ b/config/salt/tools.sls
@@ -64,7 +64,7 @@ htop:
 
 wp_cli:
   cmd.run:
-    - name: curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar; chmod +x wp-cli.phar; sudo mv wp-cli.phar /usr/bin/wp
+    - name: curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar; chmod +x wp-cli-nightly.phar; sudo mv wp-cli-nightly.phar /usr/bin/wp
     - user: {{ grains['user'] }}
     - require:
       - pkg: php5-cli


### PR DESCRIPTION
In #121 we switched to downloading the nightly release of wp-cli. However the filename wasn't updated in the subsequent commands meaning the nightly build was downloaded but not installed.

```
curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar; chmod +x wp-cli.phar; sudo mv wp-cli.phar /usr/bin/wp
chmod: wp-cli.phar: No such file or directory
mv: rename wp-cli.phar to /usr/bin/wp: No such file or directory
```