### PR TITLE
Set value for SERVER_NAME

### DIFF
--- a/config/salt/config/nginx/default
+++ b/config/salt/config/nginx/default
@@ -73,6 +73,9 @@ server {
                 # With php5-fpm:
                 fastcgi_index index.php;
                 include fastcgi_params;
+
+                # Set server name
+                fastcgi_param SERVER_NAME $host;
         }
 
 }


### PR DESCRIPTION
<img width="587" alt="screenshot 2015-11-10 10 00 29" src="https://cloud.githubusercontent.com/assets/30460/11059503/066c283c-8792-11e5-8e3e-dfd4ab8dbc28.png">

As far as I understand, this should be set in the fastcgi_params file which is included here: https://github.com/humanmade/Salty-WordPress/blob/master/config/salt/config/nginx/default#L75

I created that file in the same folder locally and added `fastcgi_param SERVER_NAME $host;`
But on `vagrant reload` it hasn't changed the value.
Am I doing it wrong?