### PR TITLE
Install XDebug for vagrant machine

### DIFF
--- a/config/salt/config/php5-fpm/php.ini
+++ b/config/salt/config/php5-fpm/php.ini
@@ -130,9 +130,9 @@ default_socket_timeout = 60
 
 {% if grains['user'] == 'vagrant' %}
 ; Enable XDebug debugging
-xdebug.profiler_aggregate = on
-xdebug.profiler_append = on
-xdebug.profiler_enable = on
+xdebug.profiler_aggregate = off
+xdebug.profiler_append = off
+xdebug.profiler_enable = off
 xdebug.profiler_enable_trigger = on
 xdebug.idekey = "vagrant"
 xdebug.remote_autostart = on

--- a/config/salt/config/php5-fpm/php.ini
+++ b/config/salt/config/php5-fpm/php.ini
@@ -141,4 +141,5 @@ xdebug.remote_cookie_expire_time = 3600
 xdebug.remote_enable = on
 xdebug.remote_port = 9000
 xdebug.remote_host = "192.168.50.10"
+xdebug.overload_var_dump = 0
 {% endif %}

--- a/config/salt/php_fpm.sls
+++ b/config/salt/php_fpm.sls
@@ -15,7 +15,7 @@ php_stack:
       - pkg: php5-cli
       - pkg: php-apc
       - pkg: mysql-client
-{% if grains['user'] != 'vagrant' %}
+{% if grains['user'] == 'vagrant' %}
       - pkg: php5-xdebug
 {% endif %}
     - watch:
@@ -50,7 +50,7 @@ php_imagick:
   pkg.installed:
     - name: php5-imagick
 
-{% if grains['user'] != 'vagrant' %}
+{% if grains['user'] == 'vagrant' %}
 php_xdebug:
   pkg.installed:
     - name: php5-xdebug

--- a/config/salt/php_fpm.sls
+++ b/config/salt/php_fpm.sls
@@ -15,6 +15,9 @@ php_stack:
       - pkg: php5-cli
       - pkg: php-apc
       - pkg: mysql-client
+{% if grains['user'] != 'vagrant' %}
+      - pkg: php5-xdebug
+{% endif %}
     - watch:
       - file: /etc/php5/fpm/php.ini
       - file: /etc/php5/fpm/pool.d/www.conf
@@ -46,6 +49,12 @@ php_curl:
 php_imagick:
   pkg.installed:
     - name: php5-imagick
+
+{% if grains['user'] != 'vagrant' %}
+php_xdebug:
+  pkg.installed:
+    - name: php5-xdebug
+{% endif %}
 
 # php5-imagick also requires imagemagick
 imagemagick:


### PR DESCRIPTION
Makes sure xdebug is installed on a vagrant machine

Optimises the xdebug config - profiler settings caused hdd to fill up with unnecessary amount of cachegrind logs