### PR TITLE
Fix rewrite rules for subfolder installs

### DIFF
--- a/config/salt/config/nginx/default
+++ b/config/salt/config/nginx/default
@@ -49,8 +49,8 @@ server {
         # if the file doest exist for wp-admin/* or wp-*.php, try looking in the parent dir
         if ( !-e $request_filename ) {
                 rewrite /wp-admin$ $scheme://$host$uri/ permanent;
-                rewrite ^(/[^/]+)?(/wp-.*) $2 last;
-                rewrite ^(/[^/]+)?(/.*\.php) $2 last;
+                rewrite ^(/[^/]+)?(/wp-.*) /wordpress$2 last;
+                rewrite ^(/[^/]+)?(/.*\.php) /wordpress$2 last;
         }
 
         # wordpress multisite files handler (this is technically legacy but


### PR DESCRIPTION
Currently gets into a redirect loop when the project has WP under a `wordpress` folder so we should match the URL rewrite for subdomain admin

cc @missjwo 