### PR TITLE
Add workaround for invalid puppetlabs.com gpg key in vagrant box.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,14 @@ FileUtils.mkdir_p(File.dirname(__FILE__)+'/projects')
 FileUtils.mkdir_p(File.dirname(__FILE__)+'/projects/default')
 FileUtils.mkdir_p(File.dirname(__FILE__)+'/logs')
 
+update_script = <<SCRIPT
+  wget https://apt.puppetlabs.com/pubkey.gpg
+  apt-key add pubkey.gpg
+  apt-get update --yes
+  # This for the gpg bug https://github.com/puphpet/puphpet/commit/ea07fd4564077473ff962b3ddd8a3feba0f92cd6
+  yes "Y" | DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes
+SCRIPT
+
 Vagrant.configure("2") do |config|
 
   vagrant_version = Vagrant::VERSION.sub(/^v/, '') 
@@ -36,6 +44,8 @@ Vagrant.configure("2") do |config|
   if File.exists?(File.join(File.dirname(__FILE__),'Customfile')) then
     eval(IO.read(File.join(File.dirname(__FILE__),'Customfile')), binding)
   end
+
+  config.vm.provision "shell", inline: update_script
 
   config.vm.provision :salt do |salt|
     salt.verbose = true


### PR DESCRIPTION
Installing Salty-WordPress on the latest Vagrant (1.8.5) on either VirtualBox (not sure version number) or VMWare Fusion (8.1.1) does not fail because a GPG key for Puppet/Puphpet is failing. I assume this is because the .box file is based on some old version of Ubuntu etc.

Entire log output is here https://gist.github.com/paulgibbs/12a293bc7189f0080b79123f6fa974e4 see line 972 onwards.

This PR is a fix/workaround for the vagrantfile that I found somewhere on github -- I can't find the original source. This seems to work for me -- it fixes this error and doesn't seem to have any negative consequence (still testing).
